### PR TITLE
Fix profile image to be clipped to fit within the circle

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -132,6 +132,7 @@ div.content
 {
     width: 200px;
     height: 200px;
+    object-fit: cover;
 }
 .info
 {


### PR DESCRIPTION
I would like to set up my profile with an image size of 300x500.
And I noticed the image lost its aspect ratio is being squeezed and fit into the circle.
So I added a fix in the css to allow the image to be displayed properly and clipped to fit in the circle.